### PR TITLE
Components that allow favoriting and playing stations now send vote a…

### DIFF
--- a/src/app/api/modify/clicks/route.ts
+++ b/src/app/api/modify/clicks/route.ts
@@ -12,10 +12,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
     const baseUrl: string = await getBaseUrl();
 
     if (!request.nextUrl.searchParams.get('uuid')) {
-      throw new HTTPError(
-        'Station UUID missing. Please include a station UUID in the search params.',
-        400
-      );
+      throw new HTTPError('Station UUID missing.', 400);
     }
 
     const stationUUID: string = request.nextUrl.searchParams.get('uuid')?.toString() || '';

--- a/src/app/api/modify/votes/route.ts
+++ b/src/app/api/modify/votes/route.ts
@@ -10,15 +10,15 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
     const baseUrl: string = await getBaseUrl();
 
     if (!request.nextUrl.searchParams.get('uuid')) {
-      throw new HTTPError(
-        'Station UUID missing. Please include a station UUID in the search params.',
-        400
-      );
+      throw new HTTPError('Station UUID missing.', 400);
     }
 
     const stationUUID: string = request.nextUrl.searchParams.get('uuid')?.toString() || '';
     const url: string = `${baseUrl}/vote/${stationUUID}`;
     const res: globalThis.Response = await RadioAPIFetch(url);
+
+    const test = await res.json();
+    console.log(test);
 
     if (!res.ok) {
       throw new Error(`Failed to update vote count for stationUUID: ${stationUUID}`);

--- a/src/components/ContextProviders/FavoritesContext.tsx
+++ b/src/components/ContextProviders/FavoritesContext.tsx
@@ -138,7 +138,7 @@ export const FavoritesContextProvider = ({
         station: station,
       };
 
-      const res: globalThis.Response = await handleAPIFetch(
+      let res: globalThis.Response = await handleAPIFetch(
         await fetch('/api/favorites', {
           method: 'POST',
           headers: {
@@ -154,6 +154,16 @@ export const FavoritesContextProvider = ({
       );
       setFavoritedStations((prev) => (prev ? [...prev, station] : [station]));
       const data: { message: string } = await res.json();
+
+      /*
+        Note that the radio browser votes API may not reflect updates to the vote count instantly.
+      */
+      res = await handleAPIFetch(
+        await fetch(`/api/modify/votes?uuid=${station.stationuuid}`, {
+          method: 'POST',
+          credentials: 'include',
+        })
+      );
 
       successToast(
         data.message,

--- a/src/components/ContextProviders/StationContext.tsx
+++ b/src/components/ContextProviders/StationContext.tsx
@@ -1,11 +1,13 @@
 'use client';
 import { RadioStation } from '@/lib/api/schemas';
+import { APIError, handleAPIError, handleAPIFetch } from '@/lib/utils';
 import React, { useState, createContext } from 'react';
 
 export interface StationContextType {
   station: RadioStation | undefined;
   setStation: React.Dispatch<React.SetStateAction<RadioStation | undefined>>;
   isPlaying: boolean;
+  playAndUpdateClickCount: (station: RadioStation) => void;
   play: () => void;
   pause: () => void;
   volume: number;
@@ -19,6 +21,26 @@ export const StationContextProvider = ({ children }: { children: React.ReactNode
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [volume, setVolume] = useState<number>(25);
 
+  const playAndUpdateClickCount = async (station: RadioStation): Promise<void> => {
+    try {
+      setIsPlaying(true);
+      const res: globalThis.Response = await handleAPIFetch(
+        await fetch(`/api/modify/clicks?uuid=${station.stationuuid}`, {
+          method: 'POST',
+          credentials: 'include',
+        })
+      );
+      const test = await res.json();
+      console.log(test);
+    } catch (error) {
+      if (error instanceof APIError) {
+        handleAPIError(error);
+      } else {
+        console.warn(`Unknown error in favorites context.`);
+      }
+    }
+  };
+
   const play = (): void => {
     setIsPlaying(true);
   };
@@ -29,7 +51,16 @@ export const StationContextProvider = ({ children }: { children: React.ReactNode
 
   return (
     <StationContext.Provider
-      value={{ station, setStation, isPlaying, play, pause, volume, setVolume }}
+      value={{
+        station,
+        setStation,
+        isPlaying,
+        playAndUpdateClickCount,
+        play,
+        pause,
+        volume,
+        setVolume,
+      }}
     >
       {children}
     </StationContext.Provider>

--- a/src/components/Favorites/FavoritesListItem.tsx
+++ b/src/components/Favorites/FavoritesListItem.tsx
@@ -190,7 +190,7 @@ const FavoritesListItem = ({
             className="cursor-pointer rounded-xl bg-linear-(--accent-gradient) p-4"
             onClick={() => {
               stationContext?.setStation(station);
-              stationContext?.play();
+              stationContext?.playAndUpdateClickCount(station);
             }}
           >
             <Play />

--- a/src/components/HomePage/CarouselCard.tsx
+++ b/src/components/HomePage/CarouselCard.tsx
@@ -173,8 +173,7 @@ const CarouselCard = ({
             className="cursor-pointer rounded-xl bg-linear-(--accent-gradient) p-4"
             onClick={() => {
               stationContext?.setStation(station);
-              stationContext?.play();
-              console.log(station);
+              stationContext?.playAndUpdateClickCount(station);
             }}
           >
             <Play className="h-[24px] min-h-[24px] w-[24px] min-w-[24px]" />

--- a/src/components/HomePage/Header.tsx
+++ b/src/components/HomePage/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
     const stations: RadioStation[] = await res.json();
     const randomStation: RadioStation = stations[Math.floor(Math.random() * stations.length)];
     stationContext?.setStation(randomStation);
-    stationContext?.play();
+    stationContext?.playAndUpdateClickCount(randomStation);
   };
 
   return (

--- a/src/components/Shared/Player/Player.tsx
+++ b/src/components/Shared/Player/Player.tsx
@@ -85,6 +85,9 @@ const Player = () => {
     }
 
     if (stationContext) {
+      /*  
+        Do not update the click count from the player.
+       */
       stationContext.play();
     }
   };

--- a/src/components/StationBrowser/StationListItem.tsx
+++ b/src/components/StationBrowser/StationListItem.tsx
@@ -186,7 +186,7 @@ const StationListItem = ({ station, stationContext, favoritesContext }: StationL
             className="cursor-pointer rounded-xl bg-linear-(--accent-gradient) p-4"
             onClick={() => {
               stationContext?.setStation(station);
-              stationContext?.play();
+              stationContext?.playAndUpdateClickCount(station);
             }}
           >
             <Play />


### PR DESCRIPTION
Components that allow favoriting and playing stations now send vote and click count modification requests to the Radio-browser API. The only exception is the Player component, in which playing the station will not update the click count. Note that the changes are not reflected immediately.